### PR TITLE
ASA fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 Build_Output/
+.vs/
 
 # Roslyn cache directories
 *.ide/

--- a/Common/Deployment/LocalPredictiveMaintenance.json
+++ b/Common/Deployment/LocalPredictiveMaintenance.json
@@ -37,7 +37,8 @@
             "type": "string",
             "metadata": {
                 "description": "The start time for Stream Analytics jobs"
-            }
+            },
+            "defaultValue": "notused"
         }
     },
     "variables": {
@@ -130,7 +131,6 @@
                     "name": "standard"
                 },
                 "OutputStartMode": "[parameters('asaStartBehavior')]",
-                "OutputStartTime": "[parameters('asaStartTime')]",
                 "EventsOutOfOrderMaxDelayInSeconds": 10,
                 "EventsOutOfOrderPolicy": "adjust",
                 "Inputs": [

--- a/Common/Deployment/PredictiveMaintenance.json
+++ b/Common/Deployment/PredictiveMaintenance.json
@@ -51,7 +51,8 @@
             "type": "string",
             "metadata": {
                 "description": "The start time for Stream Analytics jobs"
-            }
+            },
+            "defaultValue": "notused"
         },
         "simulatorDataFileName": {
             "type": "string",
@@ -175,7 +176,6 @@
                     "name": "standard"
                 },
                 "OutputStartMode": "[parameters('asaStartBehavior')]",
-                "OutputStartTime": "[parameters('asaStartTime')]",
                 "EventsOutOfOrderMaxDelayInSeconds": 10,
                 "EventsOutOfOrderPolicy": "adjust",
                 "Inputs": [

--- a/Common/Deployment/PrepareIoTSample.ps1
+++ b/Common/Deployment/PrepareIoTSample.ps1
@@ -85,11 +85,11 @@ if ($cloudDeploy)
 # Upload simulator data
 UploadFile "$projectRoot\Simulator.WebJob\Engine\Data\$simulatorDataFileName" $storageAccount.Name $resourceGroupName "simulatordata" $false
 
-# Stream analytics does not auto stop, and requires a start time for both create and update as well as stop if already exists
-[string]$startTime = (get-date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-$null = StopExistingStreamAnalyticsJobs $resourceGroupName
-$params += @{asaStartBehavior='CustomTime'}
-$params += @{asaStartTime=$startTime}
+# Stream analytics does not auto stop, and if already exists should be set to LastOutputEventTime to not lose data
+if (StopExistingStreamAnalyticsJobs $resourceGroupName)
+{
+    $params += @{asaStartBehavior='LastOutputEventTime'}
+}
 
 Write-Host "Provisioning resources, if this is the first time, this operation can take up 10 minutes..."
 $result = New-AzureResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateFile $deploymentTemplatePath -TemplateParameterObject $params -Verbose


### PR DESCRIPTION
Set defaultValue for asaStartTime for back compat
Remove use of asaStartTime in template
Change asaStartBehavior to LastOutputEventTime if there are existing jobs
ignore VS2015 .vs folder
