### PR TITLE
Restrict DocDB names to 24 chars

### DIFF
--- a/Common/Deployment/DeploymentLib.ps1
+++ b/Common/Deployment/DeploymentLib.ps1
@@ -252,6 +252,7 @@ function ValidateResourceName()
         "microsoft.documentdb/databaseaccounts"
         {
             $resourceUrl = $global:docdbSuffix
+            $resourceBaseName = $resourceBaseName.Substring(0, [System.Math]::Min(19, $resourceBaseName.Length))
         }
         "microsoft.eventhub/namespaces"
         {


### PR DESCRIPTION
DocDB’s documentation says it allows 3-50 chars, but their actual length limit varies per-region (bug 846765). Restrict to 24 chars based on their dev’s recommendation.