### PR TITLE
Lock down R Server to 9.0.10001x

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -204,7 +204,6 @@
     <None Include="Deployment\PrepareIoTSample.ps1" />
     <None Include="Deployment\LocalPredictiveMaintenance.json" />
     <None Include="Deployment\PredictiveMaintenance.json" />
-    <None Include="Deployment\Rdeploy.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/Common/Deployment/PredictiveMaintenance-R-mooncake.json
+++ b/Common/Deployment/PredictiveMaintenance-R-mooncake.json
@@ -475,7 +475,7 @@
             "publisher": "MicrosoftRServer",
             "offer": "RServer-WS2016",
             "sku": "Enterprise",
-            "version": "9.0.100013"
+            "version": "9.0.100014"
           },
           "osDisk": {
             "name": "[parameters('rServerVMName')]",

--- a/Common/Deployment/PrepareIoTSample.ps1
+++ b/Common/Deployment/PrepareIoTSample.ps1
@@ -103,7 +103,11 @@ if ($environmentName -ne "local")
             $deploymentTemplatePath = "$(Split-Path $MyInvocation.MyCommand.Path)\PredictiveMaintenance.json"
         }
         "RServer" {
-            $deploymentTemplatePath = "$(Split-Path $MyInvocation.MyCommand.Path)\PredictiveMaintenance-R.json"
+			if ($azureEnvironmentName -eq "AzureChinaCloud" ) {
+				$deploymentTemplatePath = "$(Split-Path $MyInvocation.MyCommand.Path)\PredictiveMaintenance-R-mooncake.json"
+			} else {
+				$deploymentTemplatePath = "$(Split-Path $MyInvocation.MyCommand.Path)\PredictiveMaintenance-R.json"
+			}
         }
     }
     $global:site = "https://{0}.{1}/" -f $environmentName, $global:websiteSuffix


### PR DESCRIPTION
1. R Server image has been upgraded with breaking changes for deployR, lock down previous version 9.0.100013 so that deployR configration tools can work like before.
2. Set autoUpgradeMinorVersion to be false to avoid blocking on upgrade to 1.9 for CustomScriptExtension.
3. Remove non-exist Rdeploy.ps1 file from project