### PR TITLE
Fixed header spacing, make headers render correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#Microsoft Azure IoT Suite 
+# Microsoft Azure IoT Suite 
 You can deploy preconfigured solutions that implement common Internet of Things (IoT) scenarios to Microsoft Azure using your Azure subscrption. You can use preconfigured solutions: 
 - as a starting point for your own IoT solution. 
 - to learn about the most common patterns in IoT solution design and development. 
 
 Each preconfigured solution implements a common IoT scenario and is a complete, end-to-end implementation. You can deploy the Azure IoT Suite predictive maintenance preconfigured solution from [https://www.azureiotsuite.com](https://www.azureiotsuite.com), following the guidance on provisioning pre-configured solutions outlined in this [document](https://azure.microsoft.com/en-us/documentation/articles/iot-suite-getstarted-preconfigured-solutions/). In addition, you can download the complete source code from this repository to customize and extend the solution to meet your specific requirements. 
 
-##Predictive Maintenance pre-configured solution
+## Predictive Maintenance pre-configured solution
 The predictive maintenance pre-configured solution illustrates how you can predict the point when failure is likely to occur. The solution combines key Azure IoT Suite services, including an ML workspace complete with experiments for predicting the Remaining Useful Life (RUL) of an aircraft engine, based on a public sample data set. 
 
-##Contents of this repository
+## Contents of this repository
 
 ### Docs folder:
 


### PR DESCRIPTION
The headers were using a style:

#header

Instead of 

# header

Which means they were not rendering consistently with the other solutions in the IoT Suite Preconfigured range.