### PR TITLE
Use Windows Server and R server installer to replace R server image

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -205,7 +205,7 @@
     <None Include="Deployment\PrepareIoTSample.ps1" />
     <None Include="Deployment\LocalPredictiveMaintenance.json" />
     <None Include="Deployment\PredictiveMaintenance.json" />
-    <None Include="Deployment\rdeploly.ps1" />
+    <None Include="Deployment\rdeploy.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -200,10 +200,12 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="Deployment\DeploymentLib.ps1" />
+    <None Include="Deployment\PredictiveMaintenance-R-mooncake.json" />
     <None Include="Deployment\PredictiveMaintenance-R.json" />
     <None Include="Deployment\PrepareIoTSample.ps1" />
     <None Include="Deployment\LocalPredictiveMaintenance.json" />
     <None Include="Deployment\PredictiveMaintenance.json" />
+    <None Include="Deployment\rdeploly.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/Common/Deployment/DeploymentLib.ps1
+++ b/Common/Deployment/DeploymentLib.ps1
@@ -407,7 +407,7 @@ function UploadFile()
     $file = Get-Item -Path $filePath
     $fileName = $file.Name.ToLowerInvariant()
     $storageAccountKey = (Get-AzureRmStorageAccountKey -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName).Value[0]
-    $context = New-AzureStorageContext -StorageAccountName $StorageAccountName -StorageAccountKey $storageAccountKey
+    $context = New-AzureStorageContext -StorageAccountName $StorageAccountName -StorageAccountKey $storageAccountKey -Environment $global:azureEnvironment.Name
     if (!(HostEntryExists $context.StorageAccount.BlobEndpoint.Host))
     {
         Write-Host "$(Get-Date –f $timeStampFormat) - Waiting for storage account $($context.StorageAccount.BlobEndpoint.Host) url to resolve." -NoNewline

--- a/Common/Deployment/PredictiveMaintenance-R-mooncake.json
+++ b/Common/Deployment/PredictiveMaintenance-R-mooncake.json
@@ -145,7 +145,7 @@
       "type": "string"
     },
     "rServerVMSize": {
-      "defaultValue": "Standard_D12_v2",
+      "defaultValue": "Standard_DS2",
       "type": "string"
     }
   },

--- a/Common/Deployment/PredictiveMaintenance-R-mooncake.json
+++ b/Common/Deployment/PredictiveMaintenance-R-mooncake.json
@@ -472,10 +472,10 @@
         },
         "storageProfile": {
           "imageReference": {
-            "publisher": "MicrosoftRServer",
-            "offer": "RServer-WS2016",
-            "sku": "Enterprise",
-            "version": "9.0.100014"
+            "publisher": "MicrosoftWindowsServer",
+            "offer": "WindowsServer",
+            "sku": "2016-Datacenter",
+            "version": "latest"
           },
           "osDisk": {
             "name": "[parameters('rServerVMName')]",

--- a/Common/Deployment/PredictiveMaintenance-R.json
+++ b/Common/Deployment/PredictiveMaintenance-R.json
@@ -145,7 +145,7 @@
       "type": "string"
     },
     "rServerVMSize": {
-      "defaultValue": "Standard_D12_v2",
+      "defaultValue": "Standard_DS2",
       "type": "string"
     }
   },

--- a/Common/Deployment/rdeploy.ps1
+++ b/Common/Deployment/rdeploy.ps1
@@ -1,0 +1,33 @@
+Param(
+    [parameter()]
+    [string]
+    $password="Passw0rd!"
+)
+
+(New-Object System.Net.WebClient).DownloadFile("https://aka.ms/azureiot/predictivemaintenance-r/RServerSetup.exe", "RServerSetup.exe")
+$psi = New-Object System.Diagnostics.ProcessStartInfo;
+$psi.FileName = "RServerSetup.exe";
+$psi.Arguments = "/quiet /install";
+$psi.WorkingDirectory = (Get-Item -Path ".\" -Verbose).FullName;
+$psi.UseShellExecute =$False;
+$psi.RedirectStandardOutput = $true;
+$p = [System.Diagnostics.Process]::Start($psi);
+$p.WaitForExit();
+$p.StandardOutput.ReadToEnd();
+
+$env:Path += ";C:\Program Files\dotnet"
+
+$deployrPath="C:\Program Files\Microsoft\R Server\R_SERVER\DeployR"
+$folderName = "pmdeploy"
+$zipfile = $folderName+".zip"
+
+Invoke-WebRequest -Uri https://aka.ms/azureiot/predictivemaintenance-r/rdeployzip -OutFile $zipfile
+Expand-Archive -Path $zipfile -Force
+
+cd $folderName
+$args = ("ConfigMRS.dll", "-setpassword", $password, "-deployrpath", "`"$deployrPath`"")
+
+Start-Process -FilePath "dotnet" -ArgumentList $args -WindowStyle Hidden
+cd ..
+
+exit 0


### PR DESCRIPTION
* R server 9 image with legacy deployR is not available, we use Windows Server 2016 image and R Server 9 installer as a replacement
* Fix minor bug of powershell script which is not using correct
environment when creating storage account
* Put rdeploy.ps1 script in codebase